### PR TITLE
fix: handle zero values in price filters

### DIFF
--- a/apps/server/src/app/modules/products/dto/query-product.dto.ts
+++ b/apps/server/src/app/modules/products/dto/query-product.dto.ts
@@ -47,13 +47,13 @@ export class QueryProductDto {
   @ApiProperty({ description: 'Filter by minimum price', required: false })
   @IsOptional()
   @Type(() => Number)
-  @IsPositive()
+  @Min(0)
   minPrice?: number;
 
   @ApiProperty({ description: 'Filter by maximum price', required: false })
   @IsOptional()
   @Type(() => Number)
-  @IsPositive()
+  @Min(0)
   maxPrice?: number;
 
   @ApiProperty({ description: 'Filter by minimum length of stay', required: false })

--- a/apps/server/src/app/modules/products/products.service.ts
+++ b/apps/server/src/app/modules/products/products.service.ts
@@ -109,17 +109,16 @@ export class ProductsService {
       whereConditions.entryType = ILike(`%${queryParams.entryType}%`);
     }
 
-    if (queryParams.minPrice) {
+    // Handle price filtering
+    if (queryParams.minPrice !== undefined && queryParams.maxPrice !== undefined) {
+      // Both min and max are provided
+      whereConditions.price = Between(queryParams.minPrice, queryParams.maxPrice);
+    } else if (queryParams.minPrice !== undefined) {
+      // Only min is provided
       whereConditions.price = MoreThanOrEqual(queryParams.minPrice);
-    }
-
-    if (queryParams.maxPrice) {
-      // Handle case when both min and max are specified
-      if (queryParams.minPrice) {
-        whereConditions.price = Between(queryParams.minPrice, queryParams.maxPrice);
-      } else {
-        whereConditions.price = LessThanOrEqual(queryParams.maxPrice);
-      }
+    } else if (queryParams.maxPrice !== undefined) {
+      // Only max is provided
+      whereConditions.price = LessThanOrEqual(queryParams.maxPrice);
     }
 
     if (queryParams.minLengthOfStay) {


### PR DESCRIPTION
Fix bug where setting minPrice and maxPrice to 0 wasn't filtering products correctly.
The issue was caused by using JavaScript truthiness checks which evaluate 0 as falsy,
resulting in the filter being ignored.

- Replace truthiness checks with explicit undefined checks
- Restructure price filter logic to handle all cases properly


<img width="1326" alt="image" src="https://github.com/user-attachments/assets/a8f1f9c8-712f-484f-81f0-041e9a3f477b" />
